### PR TITLE
APERTA-12985 Adjusted parallelism in build to just our four free cont…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@
 version: 2
 jobs:
   build:
-    parallelism: 6
+    parallelism: 4
     docker:
       - image: plos/aperta-circleci
         environment:


### PR DESCRIPTION
…ainers.

JIRA issue: https://jira.plos.org/jira/browse/APERTA-

#### What this PR does:

Needed to now set parallelism value in config.yml to bring us down to the four configured containers - otherwise no build

#### Special instructions for Review or PO:

Builds should block on circle while there is a mismatch between our plan and the configured parallelism so long as the configured amount is greater than the plan amount. The plan amount was reduced a week ago but this change was not made at the same time. With this change, builds should be good again.

#### Notes

none that I know of


#### Major UI changes

None

---

#### Code Review Tasks:

**Author tasks** (delete tasks that don't apply to your PR, this list should be finished before code review):

- [ ] If I made any UI changes at all, I've let the entire QA team know in the JIRA ticket and in the Aperta QA hipchat room.
- [ ] I have set the correct component(s) in the JIRA ticket
- [ ] I have set an appropriate resolution in the JIRA ticket
- [ ] If I changed the database schema, I enforced database constraints.
- [ ] If I created a migration, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] If I modified `app/services/journal_factory.rb`, I updated the base data.yml seeds file. [instructions](https://developer.plos.org/confluence/display/TAHI/Seeds+maintenance)
- [ ] I have ensured that the Heroku Review App has successfully deployed and is ready for PO UAT.
- [ ] I added an entry to `## [Unreleased]` in CHANGELOG.md

If I modified any environment variables:
- [ ] I made a pull request to change the files on the [molten repo](https://github.com/PLOS/molten/tree/dev/pillar/aperta) {PR LINK}
- [ ] I double-checked the `app.json` file to make sure that the heroku review apps are still inheriting the correct environment variables from staging

If I need to migrate existing data:
- [ ] If a data-migration rake task is needed, the task is found in `lib/tasks/data_migrations` within the `data:migrate` namespace. Example task name: `aperta_9999_migration_description`
- [ ] If there are steps to take outside of `rake db:migrate` for Heroku or other environments, I added copy-pastable instructions to [the confluence release page](https://developer.plos.org/confluence/display/TAHI/Deployment+information+for+Release)
- [ ] I verified the data-migration's results with `rake db:test_migrations` (complicated migrations should also have real specs)
- [ ] I've talked through the ramifications of the data-migration with Product Owners in regards to deployment timing
- [ ] If I created a data migration, I added pre- and post-migration assertions.

**Reviewer tasks** (these should be checked or somehow noted before passing on to PO):
- [ ] I read through the JIRA ticket's AC before doing the rest of the review
- [ ] I ran the code (in the review environment or locally). I agree the running code fulfills the Acceptance Criteria as stated on the JIRA ticket
- [ ] I read the code; it looks good
- [ ] I have found the tests to be sufficient for both positive and negative test cases
